### PR TITLE
Emit expected events when destorying a model

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,48 @@ yield User.forge({ id: 1000 }).destroy({ hardDelete: true })
 // Retrieve a soft deleted row even with the plugin enabled. Works for
 // eager loaded relations too
 let user = yield User.forge({ id: 1000 }).fetch({ withDeleted: true })
+
+// By default soft deletes also emit "destroying" and "destroyed" events. You
+// can easily disable this behavior when setting the plugin
+bookshelf.plugin(require('bookshelf-paranoia'), { events: false })
+
+// Disable only one event
+bookshelf.plugin(require('bookshelf-paranoia'), {
+  events: { destroying: false }
+})
+
+// Enable saving, updating, saved, and updated. This will turn on all events
+// since destroying and destroyed are already on by default
+bookshelf.plugin(require('bookshelf-paranoia'), {
+  events: {
+    saving: true,
+    updating: true,
+    saved: true,
+    updated: true
+  }
+})
+```
+
+### Detecting soft deletes
+
+By listening to the default events emitted by bookshelf when destroying a model
+you're able to detect if that model is being soft deleted.
+
+```javascript
+let model = new User({ id: 1000 })
+
+// Watch for deletes as usual
+model.on('destroying', (model, options) => {
+  if (options.softDelete) console.log(`User ${model.id} is being soft deleted!`)
+})
+
+model.on('destroying', (model, options) => {
+  if (options.softDelete) console.log(`User ${model.id} has been soft deleted!`)
+})
+
+yield model.destroy()
+// User 1000 is being soft deleted!
+// User 1000 has been soft deleted!
 ```
 
 ### Testing

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/estate/bookshelf-paranoia#readme",
   "dependencies": {
+    "lodash.merge": "^4.3.5",
     "lodash.result": "^4.3.0"
   },
   "devDependencies": {

--- a/test/fixtures/custom-db.js
+++ b/test/fixtures/custom-db.js
@@ -1,0 +1,27 @@
+'use strict'
+
+let co = require('co')
+let db = require('../db')
+
+exports.generate = co.wrap(function * (tableName, tableSchema, bookshelfConfig) {
+  // Setup the new table
+  yield db.knex.schema.createTable(tableName, tableSchema)
+
+  // Create a new bookshelf instance and hook it
+  let bookshelf = require('bookshelf')(db.knex)
+  bookshelfConfig.call(bookshelfConfig, bookshelf)
+
+  return bookshelf
+})
+
+exports.testTable = co.wrap(function * (bookshelfConfig) {
+  let bookshelf = yield exports.generate('test', (table) => {
+    table.increments()
+    table.timestamp('deleted')
+  }, bookshelfConfig)
+
+  // Create one row for testing
+  yield bookshelf.knex('test').insert({ id: 1 })
+
+  return bookshelf
+})

--- a/test/spec/general.js
+++ b/test/spec/general.js
@@ -5,6 +5,7 @@ let lab = exports.lab = require('lab').script()
 let expect = require('code').expect
 
 let db = require('../db')
+let customDb = require('../fixtures/custom-db')
 let Comment = db.bookshelf.model('Comment')
 let User = db.bookshelf.model('User')
 
@@ -15,17 +16,52 @@ lab.experiment('general tests', () => {
   }))
 
   lab.test('should work', co.wrap(function * () {
-    yield Comment.forge({ id: 1 }).destroy()
+    let model = yield Comment.forge({ id: 1 }).destroy()
 
     let comment = yield Comment.forge({ id: 1 }).fetch()
     expect(comment).to.be.null()
 
     comment = yield db.knex('comments').select('*').where('id', 1)
     expect(comment[0].deleted_at).to.be.a.number()
+    expect(model.get('deleted_at')).to.be.a.date()
+  }))
+
+  lab.test('should work with transactions', co.wrap(function * () {
+    let err = yield db.bookshelf.transaction((transacting) => {
+      return Comment.forge({ id: 1 })
+      .destroy({ transacting })
+      .then(() => { throw new Error('Rollback this transaction') })
+    })
+    .catch((err) => err)
+
+    expect(err.message).to.equal('Rollback this transaction')
+
+    let comment = yield Comment.forge({ id: 1 }).fetch()
+    expect(comment.get('deleted_at')).to.be.null()
+  }))
+
+  lab.test('should throw when required', co.wrap(function * () {
+    let err = yield Comment.forge({ id: 12345 })
+    .destroy({ require: true })
+    .catch((err) => err)
+
+    expect(err).to.be.an.error('No Rows Deleted')
   }))
 
   lab.test('should allow override when destroying', co.wrap(function * () {
     yield Comment.forge({ id: 1 }).destroy()
+
+    let comment = yield db.knex('comments').select('*').where('id', 1)
+    expect(comment[0].deleted_at).to.be.a.number()
+
+    yield Comment.forge({ id: 1 }).destroy({ hardDelete: true })
+
+    comment = yield db.knex('comments').select('*').where('id', 1)
+    expect(comment[0]).to.be.undefined()
+  }))
+
+  lab.test('should properly update the document when using query', co.wrap(function * () {
+    yield Comment.where({ id: 1 }).destroy()
 
     let comment = yield db.knex('comments').select('*').where('id', 1)
     expect(comment[0].deleted_at).to.be.a.number()
@@ -47,6 +83,30 @@ lab.experiment('general tests', () => {
     expect(comment.get('deleted_at')).to.be.a.number()
   }))
 
+  lab.test('should correctly emit events', co.wrap(function * () {
+    let events = []
+    let model = Comment.forge({ id: 1 })
+
+    model.on('destroying', (model, options) => events.push(['destroying', model, options]))
+    model.on('destroyed', (model, options) => events.push(['destroyed', model, options]))
+
+    yield model.destroy({ customOption: true })
+
+    expect(events).to.have.length(2)
+    expect(events[0][0]).to.equal('destroying')
+    expect(events[0][1].get('id')).to.equal(1)
+    expect(events[0][2]).to.deep.contain({
+      softDelete: true,
+      customOption: true
+    })
+    expect(events[1][0]).to.equal('destroyed')
+    expect(events[1][1].get('id')).to.equal(1)
+    expect(events[1][2]).to.deep.contain({
+      softDelete: true,
+      customOption: true
+    })
+  }))
+
   lab.test('should hard delete when models do not have soft delete configured', co.wrap(function * () {
     yield User.forge({ id: 1 }).destroy()
 
@@ -54,18 +114,10 @@ lab.experiment('general tests', () => {
   }))
 
   lab.test('should allow overriding the field name', co.wrap(function * () {
-    // Setup the new table
-    yield db.knex.schema.createTable('test', (table) => {
-      table.increments()
-      table.timestamp('deleted')
-    })
-
-    // Insert one row for testing
-    yield db.knex('test').insert({ id: 1 })
-
     // Create a new bookshelf instance
-    let bookshelf = require('bookshelf')(db.knex)
-    bookshelf.plugin(require('../../'), { field: 'deleted' })
+    let bookshelf = yield customDb.testTable((bookshelf) => {
+      bookshelf.plugin(require('../../'), { field: 'deleted' })
+    })
 
     // Create the model that corresponds to our newly created table
     let Model = bookshelf.Model.extend({ tableName: 'test', softDelete: true })
@@ -78,6 +130,186 @@ lab.experiment('general tests', () => {
     // Now try to fetch it directly though knex
     test = yield db.knex('test').select('*').where('id', 1)
     expect(test[0].deleted).to.be.a.number()
+  }))
+
+  lab.test('should allow overriding the destroyed event', co.wrap(function * () {
+    // Create a new bookshelf instance
+    let bookshelf = yield customDb.testTable((bookshelf) => {
+      bookshelf.plugin(require('../../'), {
+        field: 'deleted',
+        events: { destroyed: false }
+      })
+    })
+
+    // Create the model that corresponds to our newly created table
+    let Model = bookshelf.Model.extend({ tableName: 'test', softDelete: true })
+    let events = []
+
+    let model = Model.forge({ id: 1 })
+    model.on('destroying', (model, options) => events.push(['destroying', model, options]))
+    model.on('destroyed', (model, options) => events.push(['destroyed', model, options]))
+
+    yield model.destroy()
+
+    expect(events).to.have.length(1)
+    expect(events[0][0]).to.equal('destroying')
+  }))
+
+  lab.test('should allow overriding the destroying event', co.wrap(function * () {
+    // Create a new bookshelf instance
+    let bookshelf = yield customDb.testTable((bookshelf) => {
+      bookshelf.plugin(require('../../'), {
+        field: 'deleted',
+        events: { destroying: false }
+      })
+    })
+
+    // Create the model that corresponds to our newly created table
+    let Model = bookshelf.Model.extend({ tableName: 'test', softDelete: true })
+    let events = []
+
+    let model = Model.forge({ id: 1 })
+    model.on('destroying', (model, options) => events.push(['destroying', model, options]))
+    model.on('destroyed', (model, options) => events.push(['destroyed', model, options]))
+
+    yield model.destroy()
+
+    expect(events).to.have.length(1)
+    expect(events[0][0]).to.equal('destroyed')
+  }))
+
+  lab.test('should allow overriding the saving event', co.wrap(function * () {
+    // Create a new bookshelf instance
+    let bookshelf = yield customDb.testTable((bookshelf) => {
+      bookshelf.plugin(require('../../'), {
+        field: 'deleted',
+        events: {
+          destroying: false,
+          updating: false,
+          saving: true
+        }
+      })
+    })
+
+    // Create the model that corresponds to our newly created table
+    let Model = bookshelf.Model.extend({ tableName: 'test', softDelete: true })
+    let events = []
+
+    let model = Model.forge({ id: 1 })
+    model.on('saving', (model, attrs, options) => events.push([model, attrs, options]))
+
+    yield model.destroy()
+
+    expect(events).to.have.length(1)
+    expect(events[0][0].id).to.equal(1)
+    expect(events[0][1].deleted).to.be.a.date()
+    expect(events[0][2].previousAttributes.deleted).to.not.exist()
+  }))
+
+  lab.test('should allow overriding the updating event', co.wrap(function * () {
+    // Create a new bookshelf instance
+    let bookshelf = yield customDb.testTable((bookshelf) => {
+      bookshelf.plugin(require('../../'), {
+        field: 'deleted',
+        events: {
+          destroying: false,
+          updating: true,
+          saving: true
+        }
+      })
+    })
+
+    // Create the model that corresponds to our newly created table
+    let Model = bookshelf.Model.extend({ tableName: 'test', softDelete: true })
+    let events = []
+
+    let model = Model.forge({ id: 1 })
+    model.on('updating', (model, attrs, options) => events.push([model, attrs, options]))
+
+    yield model.destroy()
+
+    expect(events).to.have.length(1)
+    expect(events[0][0].id).to.equal(1)
+    expect(events[0][1].deleted).to.be.a.date()
+    expect(events[0][2].previousAttributes.deleted).to.not.exist()
+  }))
+
+  lab.test('should allow overriding the saved event', co.wrap(function * () {
+    // Create a new bookshelf instance
+    let bookshelf = yield customDb.testTable((bookshelf) => {
+      bookshelf.plugin(require('../../'), {
+        field: 'deleted',
+        events: {
+          destroyed: false,
+          updated: false,
+          saved: true
+        }
+      })
+    })
+
+    // Create the model that corresponds to our newly created table
+    let Model = bookshelf.Model.extend({ tableName: 'test', softDelete: true })
+    let events = []
+
+    let model = Model.forge({ id: 1 })
+    model.on('saved', (model, attrs, options) => events.push([model, attrs, options]))
+
+    yield model.destroy()
+
+    expect(events).to.have.length(1)
+    expect(events[0][0].id).to.equal(1)
+    expect(events[0][1]).to.equal(1)
+    expect(events[0][2].previousAttributes.deleted).to.not.exist()
+  }))
+
+  lab.test('should allow overriding the updated event', co.wrap(function * () {
+    // Create a new bookshelf instance
+    let bookshelf = yield customDb.testTable((bookshelf) => {
+      bookshelf.plugin(require('../../'), {
+        field: 'deleted',
+        events: {
+          destroyed: false,
+          updated: true,
+          saved: false
+        }
+      })
+    })
+
+    // Create the model that corresponds to our newly created table
+    let Model = bookshelf.Model.extend({ tableName: 'test', softDelete: true })
+    let events = []
+
+    let model = Model.forge({ id: 1 })
+    model.on('updated', (model, attrs, options) => events.push([model, attrs, options]))
+
+    yield model.destroy()
+
+    expect(events).to.have.length(1)
+    expect(events[0][0].id).to.equal(1)
+    expect(events[0][1]).to.equal(1)
+    expect(events[0][2].previousAttributes.deleted).to.not.exist()
+  }))
+
+  lab.test('should allow disabling events', co.wrap(function * () {
+    // Create a new bookshelf instance
+    let bookshelf = yield customDb.testTable((bookshelf) => {
+      bookshelf.plugin(require('../../'), {
+        field: 'deleted',
+        events: false
+      })
+    })
+
+    // Create the model that corresponds to our newly created table
+    let Model = bookshelf.Model.extend({ tableName: 'test', softDelete: true })
+    let events = []
+
+    let model = Model.forge({ id: 1 })
+    model.on('destroying', (model, options) => events.push(['destroying', model, options]))
+    model.on('destroyed', (model, options) => events.push(['destroyed', model, options]))
+
+    yield model.destroy()
+
+    expect(events).to.have.length(0)
   }))
 })
 


### PR DESCRIPTION
When soft deleting a model we must be sure to also emit `destroying` and `destroyed` so it won't break compatibility with existing code.