### PR TITLE
Add sentinel column support

### DIFF
--- a/test/fixtures/custom-db.js
+++ b/test/fixtures/custom-db.js
@@ -14,10 +14,25 @@ exports.generate = co.wrap(function * (tableName, tableSchema, bookshelfConfig) 
   return bookshelf
 })
 
-exports.testTable = co.wrap(function * (bookshelfConfig) {
+exports.altFieldTable = co.wrap(function * (bookshelfConfig) {
   let bookshelf = yield exports.generate('test', (table) => {
     table.increments()
     table.timestamp('deleted')
+  }, bookshelfConfig)
+
+  // Create one row for testing
+  yield bookshelf.knex('test').insert({ id: 1 })
+
+  return bookshelf
+})
+
+exports.sentinelTable = co.wrap(function * (bookshelfConfig) {
+  let bookshelf = yield exports.generate('test', (table) => {
+    table.increments()
+    table.integer('value')
+    table.timestamp('deleted_at')
+    table.boolean('active').nullable()
+    table.unique(['value', 'active'])
   }, bookshelfConfig)
 
   // Create one row for testing

--- a/test/spec/general.js
+++ b/test/spec/general.js
@@ -115,7 +115,7 @@ lab.experiment('general tests', () => {
 
   lab.test('should allow overriding the field name', co.wrap(function * () {
     // Create a new bookshelf instance
-    let bookshelf = yield customDb.testTable((bookshelf) => {
+    let bookshelf = yield customDb.altFieldTable((bookshelf) => {
       bookshelf.plugin(require('../../'), { field: 'deleted' })
     })
 
@@ -134,7 +134,7 @@ lab.experiment('general tests', () => {
 
   lab.test('should allow overriding the destroyed event', co.wrap(function * () {
     // Create a new bookshelf instance
-    let bookshelf = yield customDb.testTable((bookshelf) => {
+    let bookshelf = yield customDb.altFieldTable((bookshelf) => {
       bookshelf.plugin(require('../../'), {
         field: 'deleted',
         events: { destroyed: false }
@@ -157,7 +157,7 @@ lab.experiment('general tests', () => {
 
   lab.test('should allow overriding the destroying event', co.wrap(function * () {
     // Create a new bookshelf instance
-    let bookshelf = yield customDb.testTable((bookshelf) => {
+    let bookshelf = yield customDb.altFieldTable((bookshelf) => {
       bookshelf.plugin(require('../../'), {
         field: 'deleted',
         events: { destroying: false }
@@ -180,7 +180,7 @@ lab.experiment('general tests', () => {
 
   lab.test('should allow overriding the saving event', co.wrap(function * () {
     // Create a new bookshelf instance
-    let bookshelf = yield customDb.testTable((bookshelf) => {
+    let bookshelf = yield customDb.altFieldTable((bookshelf) => {
       bookshelf.plugin(require('../../'), {
         field: 'deleted',
         events: {
@@ -208,7 +208,7 @@ lab.experiment('general tests', () => {
 
   lab.test('should allow overriding the updating event', co.wrap(function * () {
     // Create a new bookshelf instance
-    let bookshelf = yield customDb.testTable((bookshelf) => {
+    let bookshelf = yield customDb.altFieldTable((bookshelf) => {
       bookshelf.plugin(require('../../'), {
         field: 'deleted',
         events: {
@@ -236,7 +236,7 @@ lab.experiment('general tests', () => {
 
   lab.test('should allow overriding the saved event', co.wrap(function * () {
     // Create a new bookshelf instance
-    let bookshelf = yield customDb.testTable((bookshelf) => {
+    let bookshelf = yield customDb.altFieldTable((bookshelf) => {
       bookshelf.plugin(require('../../'), {
         field: 'deleted',
         events: {
@@ -264,7 +264,7 @@ lab.experiment('general tests', () => {
 
   lab.test('should allow overriding the updated event', co.wrap(function * () {
     // Create a new bookshelf instance
-    let bookshelf = yield customDb.testTable((bookshelf) => {
+    let bookshelf = yield customDb.altFieldTable((bookshelf) => {
       bookshelf.plugin(require('../../'), {
         field: 'deleted',
         events: {
@@ -292,7 +292,7 @@ lab.experiment('general tests', () => {
 
   lab.test('should allow disabling events', co.wrap(function * () {
     // Create a new bookshelf instance
-    let bookshelf = yield customDb.testTable((bookshelf) => {
+    let bookshelf = yield customDb.altFieldTable((bookshelf) => {
       bookshelf.plugin(require('../../'), {
         field: 'deleted',
         events: false

--- a/test/spec/sentinel.js
+++ b/test/spec/sentinel.js
@@ -1,0 +1,75 @@
+'use strict'
+
+let co = require('co')
+let lab = exports.lab = require('lab').script()
+let expect = require('code').expect
+
+let db = require('../db')
+let customDb = require('../fixtures/custom-db')
+
+lab.experiment('sentinel', () => {
+  lab.beforeEach(co.wrap(function * () {
+    yield db.reset()
+    yield db.knex.seed.run()
+  }))
+
+  lab.test('should set the sentinel column to true on creation', co.wrap(function * () {
+    let bookshelf = yield customDb.sentinelTable((bookshelf) => {
+      bookshelf.plugin(require('../../'), { sentinel: 'active' })
+    })
+    let Model = bookshelf.Model.extend({ tableName: 'test', softDelete: true })
+
+    let model = yield Model.forge().save()
+    expect(model.get('active')).to.equal(true)
+  }))
+
+  lab.test('should null the sentinel column on deletion', co.wrap(function * () {
+    let bookshelf = yield customDb.sentinelTable((bookshelf) => {
+      bookshelf.plugin(require('../../'), { sentinel: 'active' })
+    })
+    let Model = bookshelf.Model.extend({ tableName: 'test', softDelete: true })
+
+    let model = yield Model.forge().save().then((model) => model.destroy())
+    expect(model.get('active')).to.be.null()
+  }))
+
+  lab.test('should do nothing if the sentinel setting is null', co.wrap(function * () {
+    let bookshelf = yield customDb.sentinelTable((bookshelf) => {
+      bookshelf.plugin(require('../../'), { sentinel: null })
+    })
+    let Model = bookshelf.Model.extend({ tableName: 'test', softDelete: true })
+
+    let model = yield Model.forge().save()
+    expect(model.has('active')).to.be.false()
+  }))
+
+  lab.test('should error if the sentinel column does not exist', co.wrap(function * () {
+    let bookshelf = yield customDb.altFieldTable((bookshelf) => {
+      bookshelf.plugin(require('../../'), { sentinel: 'active' })
+    })
+    let Model = bookshelf.Model.extend({ tableName: 'test', softDelete: true })
+
+    let err = yield Model.forge().save().catch((err) => err)
+    expect(err).to.be.an.error(/has no column/)
+  }))
+
+  lab.experiment('with a unique constraint including the sentinel column', () => {
+    lab.test('should enforce a single active row', co.wrap(function * () {
+      let bookshelf = yield customDb.sentinelTable((bookshelf) => {
+        bookshelf.plugin(require('../../'), { sentinel: 'active' })
+      })
+      let Model = bookshelf.Model.extend({ tableName: 'test', softDelete: true })
+
+      let model = yield Model.forge({ value: 123 }).save()
+      let err = yield Model.forge({ value: 123 }).save().catch((err) => err)
+      expect(err).to.be.an.error(/UNIQUE constraint failed/)
+
+      yield model.destroy()
+      model = yield Model.forge({ value: 123 }).save()
+      expect(model.get('value')).to.equal(123)
+
+      let count = yield Model.where({ value: 123 }).count('*', { withDeleted: true })
+      expect(count).to.equal(2)
+    }))
+  })
+})


### PR DESCRIPTION
Due to limitations with some DBMSes, constraining a soft-delete-enabled
model to "only one active instance" is difficult: any unique index will
capture both undeleted and deleted rows. There are ways around this,
e.g., scoped indexes (WHERE deleted_at IS NULL), but the most portable
method involves adding a so-called sentinel column: a field that is true/1
when the row is active and NULL when it has been deleted. Since unique
indexes do not consider null fields, this allows a compound unique index
to fulfill our needs: indexing ['email', 'active'] will ensure only one
unique active email at a time, for example.

To maintain backward compatibility, sentinel functionality is disabled
by default. It can be enabled globally by setting the `sentinel` config
value to the name of the sentinel column, nominally "active". The
sentinel column should be added to all soft-deletable tables via
migration as a nullable boolean field.