### PR TITLE
Only set sentinel value for soft-deleteable tables

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = (bookshelf, settings) => {
     initialize: function () {
       modelPrototype.initialize.call(this)
 
-      if (settings.sentinel) {
+      if (this.softDelete === true && settings.sentinel) {
         this.defaults = merge({
           [settings.sentinel]: true
         }, result(this, 'defaults'))

--- a/test/spec/sentinel.js
+++ b/test/spec/sentinel.js
@@ -43,6 +43,16 @@ lab.experiment('sentinel', () => {
     expect(model.has('active')).to.be.false()
   }))
 
+  lab.test('should do nothing if soft deletion is not enabled', co.wrap(function * () {
+    let bookshelf = yield customDb.sentinelTable((bookshelf) => {
+      bookshelf.plugin(require('../../'), { sentinel: 'active' })
+    })
+    let Model = bookshelf.Model.extend({ tableName: 'test' })
+
+    let model = yield Model.forge().save().then((m) => m.destroy())
+    expect(model.has('active')).to.be.false()
+  }))
+
   lab.test('should error if the sentinel column does not exist', co.wrap(function * () {
     let bookshelf = yield customDb.altFieldTable((bookshelf) => {
       bookshelf.plugin(require('../../'), { sentinel: 'active' })


### PR DESCRIPTION
Commit cc098ad461e35a360b5a2b33591eca06f0d20772 added support for
sentinel columns, which allow unique active row constraints to be
implemented using any SQL database. However, it attempted to set the
sentinel value even for tables which were not explicitly marked as
soft-deleteable (via `softDelete: true` in the model config). Check for
that flag before enabling sentinels.