### PR TITLE
Provide universal DB solution for when require is true

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 let result = require('lodash.result')
 let merge = require('lodash.merge')
+let isEmpty = require('lodash.isempty')
 
 /**
  * A function that can be used as a plugin for bookshelf
@@ -137,7 +138,7 @@ module.exports = (bookshelf, settings) => {
         .then((resp) => {
           // Check if the caller required a row to be deleted and if
           // events weren't totally disabled
-          if (!resp && options.require) {
+          if (isEmpty(resp) && options.require) {
             throw new this.constructor.NoRowsDeletedError('No Rows Deleted')
           } else if (!settings.events) {
             return

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/estate/bookshelf-paranoia#readme",
   "dependencies": {
+    "lodash.isempty": "^4.4.0",
     "lodash.merge": "^4.3.5",
     "lodash.result": "^4.3.0"
   },


### PR DESCRIPTION
This PR fixes when `{ require: true }` is passed to `Model.destroy` for PostgreSQL. To solve this and provide a more universal solution, I have done the following:

- Add `lodash.isempty` to the project 
- Check for different possible values when query is empty 
  * `0` for SQLite
  * `[]` for PostgreSQL

You can see more about this in Knex's docs for [.update](http://knexjs.org/#Builder-update).