### PR TITLE
Use query object on model for soft deletion

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ module.exports = (bookshelf, settings) => {
           return Promise.all(events)
         })
         .then(() => {
-          let knex = bookshelf.knex(this.tableName)
+          let knex = this.query()
 
           // Check if we need to use a transaction
           if (options.transacting) {

--- a/test/spec/general.js
+++ b/test/spec/general.js
@@ -48,6 +48,20 @@ lab.experiment('general tests', () => {
     expect(err).to.be.an.error('No Rows Deleted')
   }))
 
+  lab.test('should preserve original query object', co.wrap(function * () {
+    yield Comment.forge({ article_id: 1 }).query((qb) => qb.where('id', 1)).destroy()
+    let comment1 = yield Comment.forge({ id: 1 }).fetch()
+    let comment2 = yield Comment.forge({ id: 2 }).fetch()
+    expect(comment1).to.be.null()
+    expect(comment2).to.not.be.null()
+  }))
+
+  lab.test('should delete according to query object', co.wrap(function * () {
+    yield Comment.query((qb) => qb.where('id', 2)).destroy()
+    let comment = yield Comment.forge({ id: 1 }).fetch()
+    expect(comment).to.not.be.null()
+  }))
+
   lab.test('should allow override when destroying', co.wrap(function * () {
     yield Comment.forge({ id: 1 }).destroy()
 
@@ -312,4 +326,3 @@ lab.experiment('general tests', () => {
     expect(events).to.have.length(0)
   }))
 })
-


### PR DESCRIPTION
This PR addresses bookshelf-paranoia not passing the original query builder onwards to the `destroy` method. Since a new query builder is being created, this drops all other queries in `Model.query` before `destroy` is called.

I've written regression tests to prove the bug, and also added a fix that uses [`Model.query`](http://bookshelfjs.org/#Model-instance-query) directly to preserve clauses passed to the query builder object in the model. 