### PR TITLE
Use Bluebird as promise library

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+let Promise = require('bluebird')
 let result = require('lodash.result')
 let merge = require('lodash.merge')
 let isEmpty = require('lodash.isempty')

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/estate/bookshelf-paranoia#readme",
   "dependencies": {
+    "bluebird": "^3.4.7",
     "lodash.isempty": "^4.4.0",
     "lodash.merge": "^4.3.5",
     "lodash.result": "^4.3.0"

--- a/test/spec/general.js
+++ b/test/spec/general.js
@@ -40,13 +40,23 @@ lab.experiment('general tests', () => {
     expect(comment.get('deleted_at')).to.be.null()
   }))
 
-  lab.test('should throw when required', co.wrap(function * () {
-    let err = yield Comment.forge({ id: 12345 })
-    .destroy({ require: true })
-    .catch((err) => err)
+  lab.experiment('errors', () => {
+    lab.test('should throw when required', co.wrap(function * () {
+      let err = yield Comment.forge({ id: 12345 })
+      .destroy({ require: true })
+      .catch((err) => err)
 
-    expect(err).to.be.an.error('No Rows Deleted')
-  }))
+      expect(err).to.be.an.error('No Rows Deleted')
+    }))
+
+    lab.test('allows for filtered catch', co.wrap(function * () {
+      let err = yield Comment.forge({ id: 12345 })
+      .destroy({ require: true })
+      .catch(db.bookshelf.Model.NoRowsDeletedError, (err) => err)
+
+      expect(err).to.be.an.error('No Rows Deleted')
+    }))
+  })
 
   lab.test('should preserve original query object', co.wrap(function * () {
     yield Comment.forge({ article_id: 1 }).query((qb) => qb.where('id', 1)).destroy()


### PR DESCRIPTION
This PR addresses a deviation of behavior between `bookshelf-paranoia` and `bookshelf`.

Bookshelf uses Bluebird for its backing promise library, which allows for a plethora of extra features (including filtered catch). I added a regression test demonstrates the change of behavior when using ES6 promises, and added Bluebird as a dependency to `bookshelf-paranoia`.