### PR TITLE
Supply Current Time

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,8 @@ module.exports = (bookshelf, settings) => {
      * @param {Object} [options] The default options parameters from Model.destroy
      * @param {Boolean} [options.hardDelete=false] Override the default soft
      * delete behavior and allow a model to be hard deleted
+     * @param {Number|Date} [options.currentTime=false] Override the default Date.now() with a
+     * client supplied time
      * @return {Promise} A promise that's fulfilled when the model has been
      * hard or soft deleted
      */
@@ -96,8 +98,10 @@ module.exports = (bookshelf, settings) => {
           softDelete: true
         }, options)
 
+        const now = options.currentTime ? new Date(options.currentTime) : new Date()
+
         // Attributes to be passed to events
-        let attrs = { [settings.field]: new Date() }
+        let attrs = { [settings.field]: now }
         // Null out sentinel column, since NULL is not considered by SQL unique indexes
         if (settings.sentinel) {
           attrs[settings.sentinel] = null

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = (bookshelf, settings) => {
     if (!options.isEager || options.parentResponse) {
       let softDelete = this.model ? this.model.prototype.softDelete : this.softDelete
 
-      if (softDelete === true && options.withDeleted !== true) {
+      if (softDelete && !options.withDeleted) {
         options.query.whereNull(`${result(this, 'tableName')}.${settings.field}`)
       }
     }
@@ -68,7 +68,7 @@ module.exports = (bookshelf, settings) => {
     initialize: function () {
       modelPrototype.initialize.call(this)
 
-      if (this.softDelete === true && settings.sentinel) {
+      if (this.softDelete && settings.sentinel) {
         this.defaults = merge({
           [settings.sentinel]: true
         }, result(this, 'defaults'))
@@ -88,7 +88,7 @@ module.exports = (bookshelf, settings) => {
      */
     destroy: function (options) {
       options = options || {}
-      if (this.softDelete === true && options.hardDelete !== true) {
+      if (this.softDelete && !options.hardDelete) {
         // Add default values to options
         options = merge({
           method: 'update',

--- a/index.js
+++ b/index.js
@@ -83,8 +83,7 @@ module.exports = (bookshelf, settings) => {
      * @param {Object} [options] The default options parameters from Model.destroy
      * @param {Boolean} [options.hardDelete=false] Override the default soft
      * delete behavior and allow a model to be hard deleted
-     * @param {Number|Date} [options.currentTime=false] Override the default Date.now() with a
-     * client supplied time
+     * @param {Number|Date} [options.currentTime=new Date()] Use a client supplied time
      * @return {Promise} A promise that's fulfilled when the model has been
      * hard or soft deleted
      */

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ module.exports = (bookshelf, settings) => {
      * @param {Object} [options] The default options parameters from Model.destroy
      * @param {Boolean} [options.hardDelete=false] Override the default soft
      * delete behavior and allow a model to be hard deleted
-     * @param {Number|Date} [options.currentTime=new Date()] Use a client supplied time
+     * @param {Number|Date} [options.date=new Date()] Use a client supplied time
      * @return {Promise} A promise that's fulfilled when the model has been
      * hard or soft deleted
      */
@@ -97,7 +97,7 @@ module.exports = (bookshelf, settings) => {
           softDelete: true
         }, options)
 
-        const now = options.currentTime ? new Date(options.currentTime) : new Date()
+        const now = options.date ? new Date(options.date) : new Date()
 
         // Attributes to be passed to events
         let attrs = { [settings.field]: now }

--- a/index.js
+++ b/index.js
@@ -90,11 +90,11 @@ module.exports = (bookshelf, settings) => {
       options = options || {}
       if (this.softDelete === true && options.hardDelete !== true) {
         // Add default values to options
-        options = merge(options, {
+        options = merge({
           method: 'update',
           patch: true,
           softDelete: true
-        })
+        }, options)
 
         // Attributes to be passed to events
         let attrs = { [settings.field]: new Date() }

--- a/index.js
+++ b/index.js
@@ -97,10 +97,10 @@ module.exports = (bookshelf, settings) => {
           softDelete: true
         }, options)
 
-        const now = options.date ? new Date(options.date) : new Date()
+        const date = options.date ? new Date(options.date) : new Date()
 
         // Attributes to be passed to events
-        let attrs = { [settings.field]: now }
+        let attrs = { [settings.field]: date }
         // Null out sentinel column, since NULL is not considered by SQL unique indexes
         if (settings.sentinel) {
           attrs[settings.sentinel] = null

--- a/test/spec/general.js
+++ b/test/spec/general.js
@@ -28,7 +28,7 @@ lab.experiment('general tests', () => {
 
   lab.test('should work with user-provided time as Date', co.wrap(function * () {
     const now = new Date()
-    let model = yield Comment.forge({ id: 1 }).destroy({ currentTime: now })
+    let model = yield Comment.forge({ id: 1 }).destroy({ date: now })
 
     let comment = yield Comment.forge({ id: 1 }).fetch()
     expect(comment).to.be.null()
@@ -41,7 +41,7 @@ lab.experiment('general tests', () => {
 
   lab.test('should work with user-provided time as milliseconds', co.wrap(function * () {
     const now = Date.now()
-    let model = yield Comment.forge({ id: 1 }).destroy({ currentTime: now })
+    let model = yield Comment.forge({ id: 1 }).destroy({ date: now })
 
     let comment = yield Comment.forge({ id: 1 }).fetch()
     expect(comment).to.be.null()

--- a/test/spec/general.js
+++ b/test/spec/general.js
@@ -26,6 +26,32 @@ lab.experiment('general tests', () => {
     expect(model.get('deleted_at')).to.be.a.date()
   }))
 
+  lab.test('should work with user-provided time as Date', co.wrap(function * () {
+    const now = new Date()
+    let model = yield Comment.forge({ id: 1 }).destroy({ currentTime: now })
+
+    let comment = yield Comment.forge({ id: 1 }).fetch()
+    expect(comment).to.be.null()
+
+    comment = yield db.knex('comments').select('*').where('id', 1)
+    expect(comment[0].deleted_at).to.be.a.number()
+    expect(model.get('deleted_at')).to.be.a.date()
+    expect(model.get('deleted_at').getTime()).to.equal(now.getTime())
+  }))
+
+  lab.test('should work with user-provided time as milliseconds', co.wrap(function * () {
+    const now = Date.now()
+    let model = yield Comment.forge({ id: 1 }).destroy({ currentTime: now })
+
+    let comment = yield Comment.forge({ id: 1 }).fetch()
+    expect(comment).to.be.null()
+
+    comment = yield db.knex('comments').select('*').where('id', 1)
+    expect(comment[0].deleted_at).to.be.a.number()
+    expect(model.get('deleted_at')).to.be.a.date()
+    expect(model.get('deleted_at').getTime()).to.equal(now)
+  }))
+
   lab.test('should work with transactions', co.wrap(function * () {
     let err = yield db.bookshelf.transaction((transacting) => {
       return Comment.forge({ id: 1 })


### PR DESCRIPTION
I maintain an app that uses a software supplied timestamp for all timestamp fields in the database, among them the deleted_at timestamp.

This patch would allow optionally passing in `currentTime` to `Model.destroy` as a Date or milliseconds since the epoch to overwrite the default `new Date()` behaviour.

The other two commits could be removed if you don't like them. I think one fixes a bug, though.